### PR TITLE
fix: can't start on low version

### DIFF
--- a/src/main/java/de/erethon/caliburn/mob/VanillaMob.java
+++ b/src/main/java/de/erethon/caliburn/mob/VanillaMob.java
@@ -313,7 +313,7 @@ public class VanillaMob extends ExMob {
         this.id1_13 = id1_13;
         this.bukkit = bukkit;
         this.numeric = numeric;
-        species = isAvailable() ? EntityType.valueOf(bukkit) : EntityType.UNKNOWN;
+        species = isAvailable() ? EntityType.valueOf(getBukkitName()) : EntityType.UNKNOWN;
     }
 
     /**


### PR DESCRIPTION
exception on 1.12.2:  java.lang.IllegalArgumentException: No enum constant org.bukkit.entity.EntityType.ZOMBIFIED_PIGLIN